### PR TITLE
Add videos page with infinite scrolling

### DIFF
--- a/src/app/api/videos/route.ts
+++ b/src/app/api/videos/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getVideos } from '@/lib/api'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const page = Number(searchParams.get('page') || '1')
+  const limit = Number(searchParams.get('limit') || '9')
+  const siteKey = searchParams.get('siteKey') || undefined
+
+  const data = await getVideos(page, limit, siteKey)
+
+  if (!data) {
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}

--- a/src/app/videos/page.tsx
+++ b/src/app/videos/page.tsx
@@ -1,0 +1,15 @@
+import { getVideos } from '@/lib/api'
+import VideoGallery from '@/components/VideoGallery'
+
+export default async function Page() {
+  const initial = await getVideos(1, 9)
+  const videos = initial?.docs || []
+  const totalPages = initial?.totalPages || 1
+
+  return (
+    <main className="min-h-screen p-4">
+      <h1 className="mb-4 text-3xl font-bold">Videos</h1>
+      <VideoGallery initialVideos={videos} totalPages={totalPages} />
+    </main>
+  )
+}

--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+
+interface Video {
+  id: string
+  publicId: string
+}
+
+interface Props {
+  initialVideos: Video[]
+  totalPages: number
+}
+
+const CLOUDINARY_BASE = 'https://res.cloudinary.com/vaibase/video/upload/'
+
+export default function VideoGallery({ initialVideos, totalPages }: Props) {
+  const [videos, setVideos] = useState<Video[]>(initialVideos)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!loadMoreRef.current) return
+    const observer = new IntersectionObserver(async entries => {
+      if (entries[0].isIntersecting && !loading && page < totalPages) {
+        setLoading(true)
+        try {
+          const nextPage = page + 1
+          const res = await fetch(`/api/videos?page=${nextPage}`)
+          if (res.ok) {
+            const data = await res.json()
+            setVideos(prev => [...prev, ...data.docs])
+            setPage(data.page)
+          }
+        } finally {
+          setLoading(false)
+        }
+      }
+    })
+    const el = loadMoreRef.current
+    observer.observe(el)
+    return () => observer.unobserve(el)
+  }, [page, totalPages, loading])
+
+  return (
+    <div>
+      <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        {videos.map(video => (
+          <video
+            key={video.id}
+            src={`${CLOUDINARY_BASE}${video.publicId}.mp4`}
+            controls
+            className="w-full h-auto rounded-lg"
+          />
+        ))}
+      </div>
+      {page < totalPages && <div ref={loadMoreRef} className="py-4" />}
+      {loading && <p className="py-4 text-center">Loading...</p>}
+    </div>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,13 @@ interface Service {
   [key: string]: any;
 }
 
+interface Video {
+  id: string;
+  publicId: string;
+  siteKey: string;
+  [key: string]: any;
+}
+
 // API configuration
 const API_URL = process.env.PAYLOAD_PUBLIC_SERVER_URL || 'https://vae-payload-hq.payloadcms.app';
 const API_SECRET = process.env.PAYLOAD_SECRET;
@@ -152,6 +159,21 @@ export async function getSiteSettings(siteKey: string = DEFAULT_SITE_KEY): Promi
 // Fetch services
 export async function getServices(siteKey: string = DEFAULT_SITE_KEY): Promise<Service[]> {
   const data = await fetchFromPayload<Service>('/api/services', {}, siteKey);
-  
+
   return data?.docs || [];
+}
+
+// Fetch videos with pagination
+export async function getVideos(
+  page: number = 1,
+  limit: number = 9,
+  siteKey: string = DEFAULT_SITE_KEY
+): Promise<PayloadResponse<Video> | null> {
+  const data = await fetchFromPayload<Video>(
+    '/api/videos',
+    { page, limit },
+    siteKey
+  );
+
+  return data;
 }


### PR DESCRIPTION
## Summary
- extend Payload API helpers with `Video` type and `getVideos`
- proxy Payload requests via new `/api/videos` route
- create `VideoGallery` client component for responsive grid and infinite scroll
- add `/videos` page using Payload data

## Testing
- `npx next lint` *(fails: `connect EHOSTUNREACH`)*
- `npm run build` *(fails: `next: not found`)*