### PR TITLE
Use Cloudinary public ID in video gallery

### DIFF
--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 
 interface Video {
   id: string
-  publicId: string
+  cloudinaryPublicId: string
 }
 
 interface Props {
@@ -49,7 +49,7 @@ export default function VideoGallery({ initialVideos, totalPages }: Props) {
         {videos.map(video => (
           <video
             key={video.id}
-            src={`${CLOUDINARY_BASE}${video.publicId}.mp4`}
+            src={`${CLOUDINARY_BASE}${video.cloudinaryPublicId}.mp4`}
             controls
             className="w-full h-auto rounded-lg"
           />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -54,7 +54,7 @@ interface Service {
 
 interface Video {
   id: string;
-  publicId: string;
+  cloudinaryPublicId: string;
   siteKey: string;
   [key: string]: any;
 }
@@ -171,7 +171,7 @@ export async function getVideos(
 ): Promise<PayloadResponse<Video> | null> {
   const data = await fetchFromPayload<Video>(
     '/api/videos',
-    { page, limit },
+    { page, limit, fields: 'id,cloudinaryPublicId' },
     siteKey
   );
 


### PR DESCRIPTION
## Summary
- include `cloudinaryPublicId` in video type
- fetch the new field from the videos API
- render videos using `cloudinaryPublicId`

## Testing
- `npm run lint` *(fails: `next` not found)*