### PR TITLE
Display video thumbnails

### DIFF
--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useRef } from 'react'
 interface Video {
   id: string
   cloudinaryPublicId: string
+  thumbnailUrl: string
 }
 
 interface Props {
@@ -50,6 +51,7 @@ export default function VideoGallery({ initialVideos, totalPages }: Props) {
           <video
             key={video.id}
             src={`${CLOUDINARY_BASE}${video.cloudinaryPublicId}.mp4`}
+            poster={`${CLOUDINARY_BASE}${video.thumbnailUrl}`}
             controls
             className="w-full h-auto rounded-lg"
           />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,6 +55,7 @@ interface Service {
 interface Video {
   id: string;
   cloudinaryPublicId: string;
+  thumbnailUrl: string;
   siteKey: string;
   [key: string]: any;
 }
@@ -171,7 +172,7 @@ export async function getVideos(
 ): Promise<PayloadResponse<Video> | null> {
   const data = await fetchFromPayload<Video>(
     '/api/videos',
-    { page, limit, fields: 'id,cloudinaryPublicId' },
+    { page, limit, fields: 'id,cloudinaryPublicId,thumbnailUrl' },
     siteKey
   );
 


### PR DESCRIPTION
## Summary
- extend `Video` type with `thumbnailUrl`
- fetch Cloudinary thumbnail URL in videos API call
- display a Cloudinary poster image for each video

## Testing
- `npm run lint` *(fails: next not found)*